### PR TITLE
Add system UUID configuration and integrate it into telemetry

### DIFF
--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -71,6 +71,13 @@ func NewContainer(opts InitOptions) (*Container, error) {
 		LogLevel: logger.DebugLevel,
 	}
 
+	systemConfig, err := container.Filesystem.GetSystemConfig()
+	if err != nil {
+		return container, fmt.Errorf("failed to get system config: %w", err)
+	}
+
+	container.Config.SystemConfig = systemConfig
+
 	container.Logger, err = logger.NewLogger(loggerConfig)
 	if err != nil {
 		return container, fmt.Errorf("failed to initialize logger: %w", err)

--- a/internal/config/app.go
+++ b/internal/config/app.go
@@ -10,11 +10,16 @@ type Repository struct {
 	Repo  string
 }
 
+type SystemConfig struct {
+	UUID string `json:"uuid"`
+}
+
 // AppConfig represents the configuration for the application
 type AppConfig struct {
-	Name       string
-	Repository Repository
-	Version    Version
+	Name         string
+	Repository   Repository
+	Version      Version
+	SystemConfig *SystemConfig
 }
 
 // Version represents the version information for the application

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -22,6 +22,11 @@ func SendTelemetryEvent(ctx context.Context, appCfg *config.AppConfig, eventName
 	)
 	defer collector.Close()
 
+	var systemUUID string
+	if appCfg.SystemConfig != nil {
+		systemUUID = appCfg.SystemConfig.UUID
+	}
+
 	telemetryEvent := telemetry.Event{
 		Name:         eventName,
 		TraceID:      uuid.New().String(),
@@ -29,6 +34,7 @@ func SendTelemetryEvent(ctx context.Context, appCfg *config.AppConfig, eventName
 		SeverityText: severityText,
 		Body:         message,
 		Attributes: map[string]interface{}{
+			"system.uuid":        systemUUID,
 			"cli_version.code":   appCfg.Version.Version,
 			"cli_version.commit": appCfg.Version.Commit,
 			"cli_version.date":   appCfg.Version.Date,


### PR DESCRIPTION
Introduced `SystemConfig` struct to store a unique system UUID. Updated app, CLI, and telemetry modules to manage and utilize this new configuration. Ensured the UUID is generated, stored in `system.json`, and included in telemetry events for better traceability.