### PR TITLE
Enable Homebrew Tap updates via GitHub Actions and GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,6 +53,15 @@ brews:
     repository:
       owner: shaharia-lab
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+      branch: formula-update
+      pull_request:
+        enabled: true
+        draft: false
+        base:
+          owner: shaharia-lab
+          name: homebrew-tap
+          branch: main
     directory: Formula
     install: |
       bin.install "echoy"


### PR DESCRIPTION
Add support for updating the Homebrew Tap repository by including the `HOMEBREW_TAP_TOKEN` in the GitHub Actions workflow and configuring GoReleaser to create pull requests. This ensures seamless integration and automated updates to the Homebrew Tap formulas.

Closes #16 