### PR TITLE
Add checkout step to GitHub Actions labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,7 @@
 ci-workflow:
-  - .github/**
+  - changed-files:
+      - any-glob-to-any-file: '.github/**'
 
 documentation:
-  - README.md
+  - changed-files:
+      - any-glob-to-any-file: 'README.md'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,6 +12,7 @@ jobs:
       pull-requests: write
 
     steps:
+      - uses: actions/checkout@v3
       - name: Run PR Labeler
         uses: actions/labeler@v5
         with:

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -6,12 +6,13 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   greeting:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
     steps:
       - name: Send Welcome Message
         uses: actions/first-interaction@v1


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/labeler.yml` file. The change adds a step to use the `actions/checkout@v3` action before running the PR Labeler action.