### PR TITLE
Update workflows to use pull_request_target trigger

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: Pull Request Auto-Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -3,16 +3,15 @@ name: Welcome New Contributors
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
-
-permissions:
-  issues: write
-  pull-requests: write
 
 jobs:
   greeting:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Send Welcome Message
         uses: actions/first-interaction@v1


### PR DESCRIPTION
Replaced `pull_request` with `pull_request_target` in workflows to address permission limitations for forks. Additionally, moved permissions under the `jobs` section in `welcome.yml` for better scope clarity. These changes ensure smoother execution of actions for external contributions.