### PR TITLE
Add Discord notification to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Send Discord notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        uses: Ilshidur/action-discord@master
+        with:
+          args: |
+            🚀 **New Release Available!** 🚀
+            
+            Repository: **${{ github.repository }}**
+            Version: **${{ github.event.release.tag_name }}**
+            
+            ${{ github.event.release.name }}
+            
+            ${{ github.event.release.body }}
+            
+            📥 [View Release Details](${{ github.event.release.html_url }})
+            
+            Thank you for using our project! ✨


### PR DESCRIPTION
This update integrates a step to send a notification to Discord when a new release is published. The message includes details such as repository name, release version, and a link to the release. It ensures users are promptly informed of new updates via Discord.

## Related Issue(s)

- Fixes #19 

## Description

## Changes Made

-
-
-

## Testing

- [ ] Added new unit tests
- [x] Manually tested (describe steps below)

## Checklist

- [ ] My code follows the project's coding style guidelines ([CONTRIBUTING.md](./.github/CONTRIBUTING.md)).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added an entry to `CHANGELOG.md` (if applicable).
- [ ] All new and existing tests passed.

## Additional Context

