### PR TITLE
Remove "github-actions" label from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "github-actions"
     groups:
       github-actions-updates:
         patterns:


### PR DESCRIPTION
The "github-actions" label has been removed from the configuration to streamline labeling. Updates to GitHub Actions will now solely rely on the existing group settings without additional labels. This simplifies dependency management and reduces label redundancy.